### PR TITLE
Fix str error with no-browser mode

### DIFF
--- a/bin/run-radiopadre
+++ b/bin/run-radiopadre
@@ -324,7 +324,7 @@ import signal
 signal.signal(signal.SIGHUP, _handle_hup)
 
 # work out browser
-if config.BROWSER.upper() in ("NONE", "FALSE", "0"):
+if str(config.BROWSER).upper() in ("NONE", "FALSE", "0"):
     config.BROWSER = None
 
 


### PR DESCRIPTION
Fixes this
```
Traceback (most recent call last):                                                                                                                                   
  File "radiopadre-client/bin/run-radiopadre", line 327, in <module>                                                                                                                         
    if config.BROWSER.upper() in ("NONE", "FALSE", "0"):                                                                                                                                                           
AttributeError: 'bool' object has no attribute 'upper' 
```